### PR TITLE
Charges - Add Stub

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -132,6 +132,9 @@ issues:
         - stylecheck
         - funlen
         - lll
+    - path: stub
+      linters:
+        - funlen
 
     # https://github.com/go-critic/go-critic/issues/926
     - linters:

--- a/README.md
+++ b/README.md
@@ -27,12 +27,13 @@ import (
 	"log"
 
 	"github.com/benalucorp/coinbase-commerce-go"
+	"github.com/benalucorp/coinbase-commerce-go/pkg/api"
 	"github.com/benalucorp/coinbase-commerce-go/pkg/entity"
 	"github.com/benalucorp/coinbase-commerce-go/pkg/enum"
 )
 
 func main() {
-	client, err := coinbase.NewClient(coinbase.Config{
+	client, err := coinbase.NewClient(api.Config{
 		Key:              "REPLACE_WITH_YOUR_API_KEY",
 		Timeout:          0,    // Default: 1 min.
 		RetryCount:       0,    // Default: 0 = disable.

--- a/README.md
+++ b/README.md
@@ -79,6 +79,53 @@ func main() {
 
 For more example check [here](main_integration_test.go).
 
+## Test Double / Stub
+
+Sometime it's make sense to make an API call without actually calling the API. In order to support that this library has a built-in stub that can be triggered. You can enable stub by injecting certain value to the context data. You can also enforce that certain API call will always return error with specific type and
+message.
+
+```go
+package main
+
+import (
+	"context"
+	"log"
+
+	"github.com/benalucorp/coinbase-commerce-go"
+	"github.com/benalucorp/coinbase-commerce-go/pkg/api"
+	"github.com/benalucorp/coinbase-commerce-go/pkg/entity"
+	"github.com/benalucorp/coinbase-commerce-go/pkg/enum"
+	"github.com/benalucorp/coinbase-commerce-go/pkg/api/stub"
+)
+
+func AlwaysSuccess(ctx context.Context, client *coinbase.Client) {
+	// Enable stub that always success and return data.
+	ctx = stub.Enable(ctx)
+
+	// Call any client method.
+	resp, err := client.CreateCharge(ctx, &entity.CreateChargeReq{})
+	if err != nil {
+		log.Fatal(err)
+	}
+	log.Printf("%+v", resp)
+}
+
+func AlwaysError(ctx context.Context, client *coinbase.Client) {
+	// Enable stub that always error and return specific error.
+	ctx = stub.SetErrDetailResp(context.Background(), entity.ErrDetailResp{
+		Type:    "bad_request",
+		Message: "stub: error triggered",
+	})
+
+	// Call any client method.
+	resp, err := client.CreateCharge(ctx, &entity.CreateChargeReq{})
+	if err != nil {
+		log.Fatal(err)
+	}
+	log.Printf("%+v", resp)
+}
+```
+
 ## Supported API
 
 Version: 2018-03-22

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.14
 require (
 	github.com/go-resty/resty/v2 v2.6.0
 	github.com/kokizzu/gotro v1.817.1737
+	github.com/segmentio/ksuid v1.0.4
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/net v0.0.0-20210813160813-60bc85c4be6d // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect

--- a/go.sum
+++ b/go.sum
@@ -148,6 +148,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/ruudk/golang-pdf417 v0.0.0-20181029194003-1af4ab5afa58/go.mod h1:6lfFZQK844Gfx8o5WFuvpxWRwnSoipWe/p622j1v06w=
+github.com/segmentio/ksuid v1.0.4 h1:sBo2BdShXjmcugAMwjugoGUdUV0pcxY5mW4xKRn3v4c=
+github.com/segmentio/ksuid v1.0.4/go.mod h1:/XUiZBD3kVx5SmUOl55voK5yeAbBNNIed+2O73XgrPE=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=

--- a/main.go
+++ b/main.go
@@ -2,9 +2,9 @@ package coinbase
 
 import (
 	"context"
-	"errors"
 
 	"github.com/benalucorp/coinbase-commerce-go/pkg/api"
+	"github.com/benalucorp/coinbase-commerce-go/pkg/api/stub"
 	"github.com/benalucorp/coinbase-commerce-go/pkg/entity"
 )
 
@@ -15,12 +15,15 @@ func NewClient(cfg api.Config) (*Client, error) {
 	}
 
 	return &Client{
-		charges: api.NewCharges(cfg),
+		charges:     api.NewCharges(cfg),
+		chargesStub: stub.NewCharges(),
 	}, nil
 }
 
+// Client is the main client to interact with Coinbase Commerce API.
 type Client struct {
-	charges *api.Charges
+	charges     api.ChargesItf
+	chargesStub api.ChargesItf
 }
 
 // CreateCharge charge a customer with certain amount of currency.
@@ -30,10 +33,9 @@ type Client struct {
 // to the blockchain before the charge expires.
 // Reference: https://commerce.coinbase.com/docs/api/#create-a-charge
 func (c Client) CreateCharge(ctx context.Context, req *entity.CreateChargeReq) (*entity.CreateChargeResp, error) {
-	if req == nil {
-		return nil, errors.New("payload: missing")
+	if stub.Ok(ctx) {
+		return c.chargesStub.Create(ctx, req)
 	}
-
 	return c.charges.Create(ctx, req)
 }
 
@@ -42,24 +44,21 @@ func (c Client) CreateCharge(ctx context.Context, req *entity.CreateChargeReq) (
 // This information is also returned when a charge is first created.
 // Reference: https://commerce.coinbase.com/docs/api/#show-a-charge
 func (c Client) ShowCharge(ctx context.Context, req *entity.ShowChargeReq) (*entity.ShowChargeResp, error) {
-	if req == nil {
-		return nil, errors.New("payload: missing")
-	}
-
 	if err := req.Validate(); err != nil {
 		return nil, err
 	}
-
+	if stub.Ok(ctx) {
+		return c.chargesStub.Show(ctx, req)
+	}
 	return c.charges.Show(ctx, req)
 }
 
 // ListCharges lists all the charges.
 // Reference: https://commerce.coinbase.com/docs/api/#list-charges
 func (c Client) ListCharges(ctx context.Context, req *entity.ListChargesReq) (*entity.ListChargesResp, error) {
-	if req == nil {
-		return nil, errors.New("payload: missing")
+	if stub.Ok(ctx) {
+		return c.chargesStub.List(ctx, req)
 	}
-
 	return c.charges.List(ctx, req)
 }
 
@@ -73,14 +72,12 @@ func (c Client) ListCharges(ctx context.Context, req *entity.ListChargesReq) (*e
 //
 // Reference: https://commerce.coinbase.com/docs/api/#cancel-a-charge
 func (c Client) CancelCharge(ctx context.Context, req *entity.CancelChargeReq) (*entity.CancelChargeResp, error) {
-	if req == nil {
-		return nil, errors.New("payload: missing")
-	}
-
 	if err := req.Validate(); err != nil {
 		return nil, err
 	}
-
+	if stub.Ok(ctx) {
+		return c.chargesStub.Cancel(ctx, req)
+	}
 	return c.charges.Cancel(ctx, req)
 }
 
@@ -93,13 +90,11 @@ func (c Client) CancelCharge(ctx context.Context, req *entity.CancelChargeReq) (
 //
 // Reference: https://commerce.coinbase.com/docs/api/#resolve-a-charge
 func (c Client) ResolveCharge(ctx context.Context, req *entity.ResolveChargeReq) (*entity.ResolveChargeResp, error) {
-	if req == nil {
-		return nil, errors.New("payload: missing")
-	}
-
 	if err := req.Validate(); err != nil {
 		return nil, err
 	}
-
+	if stub.Ok(ctx) {
+		return c.chargesStub.Resolve(ctx, req)
+	}
 	return c.charges.Resolve(ctx, req)
 }

--- a/main.go
+++ b/main.go
@@ -3,65 +3,19 @@ package coinbase
 import (
 	"context"
 	"errors"
-	"time"
 
 	"github.com/benalucorp/coinbase-commerce-go/pkg/api"
 	"github.com/benalucorp/coinbase-commerce-go/pkg/entity"
-	"github.com/go-resty/resty/v2"
 )
 
-type Config struct {
-	// Key is the authentication API key.
-	// Most requests to the Commerce API must be authenticated with an API key.
-	// You can create an API key in your Settings page after creating a Coinbase Commerce account.
-	// Reference: https://commerce.coinbase.com/docs/api/#authentication
-	Key string
-	// Timeout describes total waiting time before a request is treated as timeout.
-	// Default: 1 min.
-	Timeout time.Duration
-	// RetryCount describes total number of retry in case error occurred.
-	// Set 0 to disable retry mechanism.
-	// Default: 3.
-	RetryCount int
-	// RetryMaxWaitTime describes total waiting time between each retry.
-	// Default: 2 second.
-	RetryMaxWaitTime time.Duration
-	// Debug describes the client to enter debug mode.
-	Debug bool
-}
-
-func (c *Config) Validate() error {
-	if c.Key == "" {
-		return errors.New("config: invalid key")
-	}
-	if c.Timeout <= 0 {
-		c.Timeout = time.Minute
-	}
-	if c.RetryCount < 0 {
-		c.RetryCount = 3
-	}
-	if c.RetryMaxWaitTime <= 0 {
-		c.RetryMaxWaitTime = 2 * time.Second
-	}
-	return nil
-}
-
 // NewClient creates a client to interact with Coinbase Commerce API.
-func NewClient(cfg Config) (*Client, error) {
+func NewClient(cfg api.Config) (*Client, error) {
 	if err := cfg.Validate(); err != nil {
 		return nil, err
 	}
 
-	r := resty.New().
-		SetHostURL(api.HostURL).
-		SetHeaders(api.DefaultHeaders(cfg.Key)).
-		SetTimeout(cfg.Timeout).
-		SetRetryCount(cfg.RetryCount).
-		SetRetryMaxWaitTime(cfg.RetryMaxWaitTime).
-		SetDebug(cfg.Debug)
-
 	return &Client{
-		charges: api.NewCharges(r),
+		charges: api.NewCharges(cfg),
 	}, nil
 }
 
@@ -76,10 +30,6 @@ type Client struct {
 // to the blockchain before the charge expires.
 // Reference: https://commerce.coinbase.com/docs/api/#create-a-charge
 func (c Client) CreateCharge(ctx context.Context, req *entity.CreateChargeReq) (*entity.CreateChargeResp, error) {
-	if c.charges == nil {
-		return nil, errors.New("client: initialize first")
-	}
-
 	if req == nil {
 		return nil, errors.New("payload: missing")
 	}
@@ -92,10 +42,6 @@ func (c Client) CreateCharge(ctx context.Context, req *entity.CreateChargeReq) (
 // This information is also returned when a charge is first created.
 // Reference: https://commerce.coinbase.com/docs/api/#show-a-charge
 func (c Client) ShowCharge(ctx context.Context, req *entity.ShowChargeReq) (*entity.ShowChargeResp, error) {
-	if c.charges == nil {
-		return nil, errors.New("client: initialize first")
-	}
-
 	if req == nil {
 		return nil, errors.New("payload: missing")
 	}
@@ -110,10 +56,6 @@ func (c Client) ShowCharge(ctx context.Context, req *entity.ShowChargeReq) (*ent
 // ListCharges lists all the charges.
 // Reference: https://commerce.coinbase.com/docs/api/#list-charges
 func (c Client) ListCharges(ctx context.Context, req *entity.ListChargesReq) (*entity.ListChargesResp, error) {
-	if c.charges == nil {
-		return nil, errors.New("client: initialize first")
-	}
-
 	if req == nil {
 		return nil, errors.New("payload: missing")
 	}
@@ -131,10 +73,6 @@ func (c Client) ListCharges(ctx context.Context, req *entity.ListChargesReq) (*e
 //
 // Reference: https://commerce.coinbase.com/docs/api/#cancel-a-charge
 func (c Client) CancelCharge(ctx context.Context, req *entity.CancelChargeReq) (*entity.CancelChargeResp, error) {
-	if c.charges == nil {
-		return nil, errors.New("client: initialize first")
-	}
-
 	if req == nil {
 		return nil, errors.New("payload: missing")
 	}
@@ -155,10 +93,6 @@ func (c Client) CancelCharge(ctx context.Context, req *entity.CancelChargeReq) (
 //
 // Reference: https://commerce.coinbase.com/docs/api/#resolve-a-charge
 func (c Client) ResolveCharge(ctx context.Context, req *entity.ResolveChargeReq) (*entity.ResolveChargeResp, error) {
-	if c.charges == nil {
-		return nil, errors.New("client: initialize first")
-	}
-
 	if req == nil {
 		return nil, errors.New("payload: missing")
 	}

--- a/main_integration_test.go
+++ b/main_integration_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/benalucorp/coinbase-commerce-go/pkg/api"
 	"github.com/benalucorp/coinbase-commerce-go/pkg/entity"
 	"github.com/benalucorp/coinbase-commerce-go/pkg/enum"
 	"github.com/kokizzu/gotro/L"
@@ -29,7 +30,7 @@ func TestMain(m *testing.M) {
 	}
 
 	var err error
-	client, err = NewClient(Config{
+	client, err = NewClient(api.Config{
 		Key:   os.Getenv("KEY"),
 		Debug: true,
 	})

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,381 @@
+package coinbase
+
+import (
+	"context"
+	"testing"
+
+	"github.com/benalucorp/coinbase-commerce-go/pkg/api"
+	"github.com/benalucorp/coinbase-commerce-go/pkg/api/stub"
+	"github.com/benalucorp/coinbase-commerce-go/pkg/entity"
+	"github.com/kokizzu/gotro/L"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestClient_CancelCharge(t *testing.T) {
+	type fields struct {
+		charges     api.ChargesItf
+		chargesStub api.ChargesItf
+	}
+	type args struct {
+		ctx context.Context
+		req *entity.CancelChargeReq
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "Stub error",
+			fields: fields{
+				charges:     nil,
+				chargesStub: stub.NewCharges(),
+			},
+			args: args{
+				ctx: stub.SetErrDetailResp(context.Background(), entity.ErrDetailResp{
+					Type:    "bad_request",
+					Message: "stub: error triggered",
+				}),
+				req: &entity.CancelChargeReq{
+					ChargeCode: "code",
+					ChargeID:   "id",
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "Stub success",
+			fields: fields{
+				charges:     nil,
+				chargesStub: stub.NewCharges(),
+			},
+			args: args{
+				ctx: stub.Enable(context.Background()),
+				req: &entity.CancelChargeReq{
+					ChargeCode: "code",
+					ChargeID:   "id",
+				},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := Client{
+				charges:     tt.fields.charges,
+				chargesStub: tt.fields.chargesStub,
+			}
+			got, err := c.CancelCharge(tt.args.ctx, tt.args.req)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("CancelCharge() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			L.Describe(got, err)
+			if !tt.wantErr {
+				assert.NotNil(t, got)
+			}
+		})
+	}
+}
+
+func TestClient_CreateCharge(t *testing.T) {
+	type fields struct {
+		charges     api.ChargesItf
+		chargesStub api.ChargesItf
+	}
+	type args struct {
+		ctx context.Context
+		req *entity.CreateChargeReq
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "Stub error",
+			fields: fields{
+				charges:     nil,
+				chargesStub: stub.NewCharges(),
+			},
+			args: args{
+				ctx: stub.SetErrDetailResp(context.Background(), entity.ErrDetailResp{
+					Type:    "bad_request",
+					Message: "stub: error triggered",
+				}),
+				req: &entity.CreateChargeReq{},
+			},
+			wantErr: true,
+		},
+		{
+			name: "Stub success",
+			fields: fields{
+				charges:     nil,
+				chargesStub: stub.NewCharges(),
+			},
+			args: args{
+				ctx: stub.Enable(context.Background()),
+				req: &entity.CreateChargeReq{},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := Client{
+				charges:     tt.fields.charges,
+				chargesStub: tt.fields.chargesStub,
+			}
+			got, err := c.CreateCharge(tt.args.ctx, tt.args.req)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("CreateCharge() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			L.Describe(got, err)
+			if !tt.wantErr {
+				assert.NotNil(t, got)
+			}
+		})
+	}
+}
+
+func TestClient_ListCharges(t *testing.T) {
+	type fields struct {
+		charges     api.ChargesItf
+		chargesStub api.ChargesItf
+	}
+	type args struct {
+		ctx context.Context
+		req *entity.ListChargesReq
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "Stub error",
+			fields: fields{
+				charges:     nil,
+				chargesStub: stub.NewCharges(),
+			},
+			args: args{
+				ctx: stub.SetErrDetailResp(context.Background(), entity.ErrDetailResp{
+					Type:    "bad_request",
+					Message: "stub: error triggered",
+				}),
+				req: &entity.ListChargesReq{},
+			},
+			wantErr: true,
+		},
+		{
+			name: "Stub success",
+			fields: fields{
+				charges:     nil,
+				chargesStub: stub.NewCharges(),
+			},
+			args: args{
+				ctx: stub.Enable(context.Background()),
+				req: &entity.ListChargesReq{},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := Client{
+				charges:     tt.fields.charges,
+				chargesStub: tt.fields.chargesStub,
+			}
+			got, err := c.ListCharges(tt.args.ctx, tt.args.req)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ListCharges() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			L.Describe(got, err)
+			if !tt.wantErr {
+				assert.NotNil(t, got)
+			}
+		})
+	}
+}
+
+func TestClient_ResolveCharge(t *testing.T) {
+	type fields struct {
+		charges     api.ChargesItf
+		chargesStub api.ChargesItf
+	}
+	type args struct {
+		ctx context.Context
+		req *entity.ResolveChargeReq
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "Stub error",
+			fields: fields{
+				charges:     nil,
+				chargesStub: stub.NewCharges(),
+			},
+			args: args{
+				ctx: stub.SetErrDetailResp(context.Background(), entity.ErrDetailResp{
+					Type:    "bad_request",
+					Message: "stub: error triggered",
+				}),
+				req: &entity.ResolveChargeReq{
+					ChargeCode: "code",
+					ChargeID:   "id",
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "Stub success",
+			fields: fields{
+				charges:     nil,
+				chargesStub: stub.NewCharges(),
+			},
+			args: args{
+				ctx: stub.Enable(context.Background()),
+				req: &entity.ResolveChargeReq{
+					ChargeCode: "code",
+					ChargeID:   "id",
+				},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := Client{
+				charges:     tt.fields.charges,
+				chargesStub: tt.fields.chargesStub,
+			}
+			got, err := c.ResolveCharge(tt.args.ctx, tt.args.req)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ResolveCharge() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			L.Describe(got, err)
+			if !tt.wantErr {
+				assert.NotNil(t, got)
+			}
+		})
+	}
+}
+
+func TestClient_ShowCharge(t *testing.T) {
+	type fields struct {
+		charges     api.ChargesItf
+		chargesStub api.ChargesItf
+	}
+	type args struct {
+		ctx context.Context
+		req *entity.ShowChargeReq
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "Stub error",
+			fields: fields{
+				charges:     nil,
+				chargesStub: stub.NewCharges(),
+			},
+			args: args{
+				ctx: stub.SetErrDetailResp(context.Background(), entity.ErrDetailResp{
+					Type:    "bad_request",
+					Message: "stub: error triggered",
+				}),
+				req: &entity.ShowChargeReq{
+					ChargeCode: "code",
+					ChargeID:   "id",
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "Stub success",
+			fields: fields{
+				charges:     nil,
+				chargesStub: stub.NewCharges(),
+			},
+			args: args{
+				ctx: stub.Enable(context.Background()),
+				req: &entity.ShowChargeReq{
+					ChargeCode: "code",
+					ChargeID:   "id",
+				},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := Client{
+				charges:     tt.fields.charges,
+				chargesStub: tt.fields.chargesStub,
+			}
+			got, err := c.ShowCharge(tt.args.ctx, tt.args.req)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ShowCharge() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			L.Describe(got, err)
+			if !tt.wantErr {
+				assert.NotNil(t, got)
+			}
+		})
+	}
+}
+
+func TestNewClient(t *testing.T) {
+	type args struct {
+		cfg api.Config
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "Missing configuration",
+			args: args{
+				cfg: api.Config{},
+			},
+			wantErr: true,
+		},
+		{
+			name: "Success",
+			args: args{
+				cfg: api.Config{
+					Key: "sample",
+				},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NewClient(tt.args.cfg)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("NewClient() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			L.Describe(got, err)
+			if !tt.wantErr {
+				assert.NotNil(t, got)
+			}
+		})
+	}
+}

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -1,5 +1,9 @@
 package api
 
+import (
+	"github.com/go-resty/resty/v2"
+)
+
 const (
 	HostURL = "https://api.commerce.coinbase.com"
 )
@@ -9,4 +13,14 @@ func DefaultHeaders(key string) map[string]string {
 		"X-CC-Api-Key": key,
 		"X-CC-Version": "2018-03-22",
 	}
+}
+
+func NewClient(cfg Config) *resty.Client {
+	return resty.New().
+		SetHostURL(HostURL).
+		SetHeaders(DefaultHeaders(cfg.Key)).
+		SetTimeout(cfg.Timeout).
+		SetRetryCount(cfg.RetryCount).
+		SetRetryMaxWaitTime(cfg.RetryMaxWaitTime).
+		SetDebug(cfg.Debug)
 }

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -1,23 +1,23 @@
 package api
 
 import (
+	"context"
+
+	"github.com/benalucorp/coinbase-commerce-go/pkg/entity"
 	"github.com/go-resty/resty/v2"
 )
 
-const (
-	HostURL = "https://api.commerce.coinbase.com"
-)
-
-func DefaultHeaders(key string) map[string]string {
-	return map[string]string{
-		"X-CC-Api-Key": key,
-		"X-CC-Version": "2018-03-22",
-	}
+type ChargesItf interface {
+	Create(ctx context.Context, req *entity.CreateChargeReq) (*entity.CreateChargeResp, error)
+	Show(ctx context.Context, req *entity.ShowChargeReq) (*entity.ShowChargeResp, error)
+	List(ctx context.Context, req *entity.ListChargesReq) (*entity.ListChargesResp, error)
+	Cancel(ctx context.Context, req *entity.CancelChargeReq) (*entity.CancelChargeResp, error)
+	Resolve(ctx context.Context, req *entity.ResolveChargeReq) (*entity.ResolveChargeResp, error)
 }
 
-func NewClient(cfg Config) *resty.Client {
+func NewRestyClient(cfg Config) *resty.Client {
 	return resty.New().
-		SetHostURL(HostURL).
+		SetHostURL(cfg.HostURL).
 		SetHeaders(DefaultHeaders(cfg.Key)).
 		SetTimeout(cfg.Timeout).
 		SetRetryCount(cfg.RetryCount).

--- a/pkg/api/authentication.go
+++ b/pkg/api/authentication.go
@@ -1,0 +1,10 @@
+package api
+
+// Reference: https://commerce.coinbase.com/docs/api/#authentication
+
+func DefaultHeaders(key string) map[string]string {
+	return map[string]string{
+		"X-CC-Api-Key": key,
+		"X-CC-Version": "2018-03-22",
+	}
+}

--- a/pkg/api/charges.go
+++ b/pkg/api/charges.go
@@ -9,7 +9,7 @@ import (
 
 func NewCharges(cfg Config) *Charges {
 	return &Charges{
-		client: NewClient(cfg),
+		client: NewRestyClient(cfg),
 	}
 }
 

--- a/pkg/api/charges.go
+++ b/pkg/api/charges.go
@@ -7,9 +7,9 @@ import (
 	"github.com/go-resty/resty/v2"
 )
 
-func NewCharges(client *resty.Client) *Charges {
+func NewCharges(cfg Config) *Charges {
 	return &Charges{
-		client: client,
+		client: NewClient(cfg),
 	}
 }
 

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -1,0 +1,42 @@
+package api
+
+import (
+	"errors"
+	"time"
+)
+
+type Config struct {
+	// Key is the authentication API key.
+	// Most requests to the Commerce API must be authenticated with an API key.
+	// You can create an API key in your Settings page after creating a Coinbase Commerce account.
+	// Reference: https://commerce.coinbase.com/docs/api/#authentication
+	Key string
+	// Timeout describes total waiting time before a request is treated as timeout.
+	// Default: 1 min.
+	Timeout time.Duration
+	// RetryCount describes total number of retry in case error occurred.
+	// Set 0 to disable retry mechanism.
+	// Default: 3.
+	RetryCount int
+	// RetryMaxWaitTime describes total waiting time between each retry.
+	// Default: 2 second.
+	RetryMaxWaitTime time.Duration
+	// Debug describes the client to enter debug mode.
+	Debug bool
+}
+
+func (c *Config) Validate() error {
+	if c.Key == "" {
+		return errors.New("config: invalid key")
+	}
+	if c.Timeout <= 0 {
+		c.Timeout = time.Minute
+	}
+	if c.RetryCount < 0 {
+		c.RetryCount = 3
+	}
+	if c.RetryMaxWaitTime <= 0 {
+		c.RetryMaxWaitTime = 2 * time.Second
+	}
+	return nil
+}

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -5,6 +5,7 @@ import (
 	"time"
 )
 
+// Config is the necessary configuration to call API.
 type Config struct {
 	// Key is the authentication API key.
 	// Most requests to the Commerce API must be authenticated with an API key.
@@ -12,19 +13,33 @@ type Config struct {
 	// Reference: https://commerce.coinbase.com/docs/api/#authentication
 	Key string
 	// Timeout describes total waiting time before a request is treated as timeout.
+	// Optional.
 	// Default: 1 min.
 	Timeout time.Duration
 	// RetryCount describes total number of retry in case error occurred.
-	// Set 0 to disable retry mechanism.
-	// Default: 3.
+	// Optional.
+	// Default: 0 = disable retry mechanism.
 	RetryCount int
 	// RetryMaxWaitTime describes total waiting time between each retry.
+	// Optional.
 	// Default: 2 second.
 	RetryMaxWaitTime time.Duration
 	// Debug describes the client to enter debug mode.
+	// Debug mode will dump the request and response on each API call.
+	// Be warn, credentials data will be dumped too.
+	// Ensure you're only this mode on safe environment like local.
+	// Optional.
+	// Default: false.
 	Debug bool
+	// HostURL describes the host url target.
+	// HostURL can be filled with your fake server host url for testing purpose.
+	// Optional.
+	// Default: https://api.commerce.coinbase.com
+	HostURL string
 }
 
+// Validate validates configuration correctness and
+// fill fields with default configuration if left empty.
 func (c *Config) Validate() error {
 	if c.Key == "" {
 		return errors.New("config: invalid key")
@@ -37,6 +52,9 @@ func (c *Config) Validate() error {
 	}
 	if c.RetryMaxWaitTime <= 0 {
 		c.RetryMaxWaitTime = 2 * time.Second
+	}
+	if c.HostURL == "" {
+		c.HostURL = "https://api.commerce.coinbase.com"
 	}
 	return nil
 }

--- a/pkg/api/stub/charges.go
+++ b/pkg/api/stub/charges.go
@@ -1,0 +1,137 @@
+package stub
+
+import (
+	"context"
+	"time"
+
+	"github.com/benalucorp/coinbase-commerce-go/pkg/entity"
+	"github.com/benalucorp/coinbase-commerce-go/pkg/enum"
+)
+
+func NewCharges() *Charges {
+	return &Charges{}
+}
+
+type Charges struct{}
+
+func (c *Charges) Create(ctx context.Context, req *entity.CreateChargeReq) (*entity.CreateChargeResp, error) {
+	if err := CreateErrResp(ctx); err.Valid() {
+		return nil, err.Error
+	}
+
+	data := CreateChargeResource()
+	data.Name = req.Name
+	data.Pricing.Local = req.LocalPrice
+	data.Description = req.Description
+	data.PricingType = req.PricingType
+
+	return &entity.CreateChargeResp{
+		Data: data,
+	}, nil
+}
+
+func (c *Charges) Show(ctx context.Context, req *entity.ShowChargeReq) (*entity.ShowChargeResp, error) {
+	if err := CreateErrResp(ctx); err.Valid() {
+		return nil, err.Error
+	}
+
+	data := CreateChargeResource()
+	if req.ChargeID != "" {
+		data.ID = req.ChargeID
+	}
+	if req.ChargeCode != "" {
+		data.Code = req.ChargeCode
+	}
+
+	return &entity.ShowChargeResp{
+		Data: data,
+	}, nil
+}
+
+func (c *Charges) List(ctx context.Context, req *entity.ListChargesReq) (*entity.ListChargesResp, error) {
+	if err := CreateErrResp(ctx); err.Valid() {
+		return nil, err.Error
+	}
+
+	pagination := CreatePagination()
+	if req.Order != "" {
+		pagination.Order = req.Order
+	}
+	if req.Limit > 0 {
+		pagination.Limit = req.Limit
+	}
+
+	data := make([]entity.ChargeResource, pagination.Limit)
+	for i := 0; i < pagination.Limit; i++ {
+		data[i] = CreateChargeResource()
+	}
+
+	pagination.CursorRange = []string{data[0].ID, data[len(data)-1].ID}
+
+	return &entity.ListChargesResp{
+		Pagination: pagination,
+		Data:       data,
+	}, nil
+}
+
+func (c *Charges) Cancel(ctx context.Context, req *entity.CancelChargeReq) (*entity.CancelChargeResp, error) {
+	if err := CreateErrResp(ctx); err.Valid() {
+		return nil, err.Error
+	}
+
+	data := CreateChargeResource()
+	if req.ChargeID != "" {
+		data.ID = req.ChargeID
+	}
+	if req.ChargeCode != "" {
+		data.Code = req.ChargeCode
+	}
+	data.Timeline = append(data.Timeline, struct {
+		Time    time.Time                    `json:"time"`
+		Status  enum.ChargeStatus            `json:"status"`
+		Context enum.ChargeUnresolvedContext `json:"context,omitempty"`
+	}{
+		Time:    time.Now(),
+		Status:  enum.ChargeStatusCanceled,
+		Context: "",
+	})
+
+	return &entity.CancelChargeResp{
+		Data: data,
+	}, nil
+}
+
+func (c *Charges) Resolve(ctx context.Context, req *entity.ResolveChargeReq) (*entity.ResolveChargeResp, error) {
+	if err := CreateErrResp(ctx); err.Valid() {
+		return nil, err.Error
+	}
+
+	data := CreateChargeResource()
+	if req.ChargeID != "" {
+		data.ID = req.ChargeID
+	}
+	if req.ChargeCode != "" {
+		data.Code = req.ChargeCode
+	}
+	data.ConfirmedAt = time.Now().Add(time.Minute)
+	data.Timeline = append(data.Timeline, []struct {
+		Time    time.Time                    `json:"time"`
+		Status  enum.ChargeStatus            `json:"status"`
+		Context enum.ChargeUnresolvedContext `json:"context,omitempty"`
+	}{
+		{
+			Time:    time.Now(),
+			Status:  enum.ChargeStatusUnresolved,
+			Context: enum.ChargeUnresolvedContextDelayed,
+		},
+		{
+			Time:    time.Now().Add(time.Minute),
+			Status:  enum.ChargeStatusResolved,
+			Context: "",
+		},
+	}...)
+
+	return &entity.ResolveChargeResp{
+		Data: data,
+	}, nil
+}

--- a/pkg/api/stub/charges_resource.go
+++ b/pkg/api/stub/charges_resource.go
@@ -1,0 +1,182 @@
+package stub
+
+import (
+	"time"
+
+	"github.com/benalucorp/coinbase-commerce-go/pkg/entity"
+	"github.com/benalucorp/coinbase-commerce-go/pkg/enum"
+	"github.com/segmentio/ksuid"
+)
+
+func CreateChargeResource() entity.ChargeResource {
+	uuid := ksuid.New().String()
+
+	return entity.ChargeResource{
+		ID:          "id-" + uuid,
+		Resource:    "charge",
+		Code:        "code-" + uuid,
+		Name:        "The Sovereign Individual",
+		Description: "Mastering the Transition to the Information Age",
+		LogoURL:     "",
+		HostedURL:   "https://commerce.coinbase.com/charges/FLJ8D3PW",
+		CreatedAt:   time.Now(),
+		ExpiresAt:   time.Now().Add(24 * time.Hour),
+		ConfirmedAt: time.Time{},
+		Checkout: struct {
+			ID string `json:"id"`
+		}{},
+		Timeline: []struct {
+			Time    time.Time                    `json:"time"`
+			Status  enum.ChargeStatus            `json:"status"`
+			Context enum.ChargeUnresolvedContext `json:"context,omitempty"`
+		}{
+			{
+				Time:    time.Now(),
+				Status:  enum.ChargeStatusNew,
+				Context: enum.ChargeUnresolvedContextNone,
+			},
+		},
+		Metadata:    struct{}{},
+		PricingType: enum.PricingTypeFixedPrice,
+		Pricing: struct {
+			Local struct {
+				Amount   string `json:"amount"`
+				Currency string `json:"currency"`
+			} `json:"local"`
+			Bitcoin struct {
+				Amount   string `json:"amount"`
+				Currency string `json:"currency"`
+			} `json:"bitcoin"`
+			BitcoinCash struct {
+				Amount   string `json:"amount"`
+				Currency string `json:"currency"`
+			} `json:"bitcoin_cash"`
+			Ethereum struct {
+				Amount   string `json:"amount"`
+				Currency string `json:"currency"`
+			} `json:"ethereum"`
+			Litecoin struct {
+				Amount   string `json:"amount"`
+				Currency string `json:"currency"`
+			} `json:"litecoin"`
+			Dogecoin struct {
+				Amount   string `json:"amount"`
+				Currency string `json:"currency"`
+			} `json:"dogecoin"`
+			USDC struct {
+				Amount   string `json:"amount"`
+				Currency string `json:"currency"`
+			} `json:"usdc"`
+			Dai struct {
+				Amount   string `json:"amount"`
+				Currency string `json:"currency"`
+			} `json:"dai"`
+		}{
+			Local: struct {
+				Amount   string `json:"amount"`
+				Currency string `json:"currency"`
+			}{
+				Amount:   "100.00",
+				Currency: "USD",
+			},
+			Bitcoin: struct {
+				Amount   string `json:"amount"`
+				Currency string `json:"currency"`
+			}{
+				Amount:   "0.00198807",
+				Currency: "BTC",
+			},
+			BitcoinCash: struct {
+				Amount   string `json:"amount"`
+				Currency string `json:"currency"`
+			}{},
+			Ethereum: struct {
+				Amount   string `json:"amount"`
+				Currency string `json:"currency"`
+			}{
+				Amount:   "0.030005000",
+				Currency: "ETH",
+			},
+			Litecoin: struct {
+				Amount   string `json:"amount"`
+				Currency string `json:"currency"`
+			}{
+				Amount:   "0.52861107",
+				Currency: "LTC",
+			},
+			Dogecoin: struct {
+				Amount   string `json:"amount"`
+				Currency string `json:"currency"`
+			}{
+				Amount:   "312.15857660",
+				Currency: "DOGE",
+			},
+			USDC: struct {
+				Amount   string `json:"amount"`
+				Currency string `json:"currency"`
+			}{
+				Amount:   "100.000000",
+				Currency: "USDC",
+			},
+			Dai: struct {
+				Amount   string `json:"amount"`
+				Currency string `json:"currency"`
+			}{
+				Amount:   "99.917617924021644154",
+				Currency: "DAI",
+			},
+		},
+		PaymentThreshold: struct {
+			OverpaymentAbsoluteThreshold struct {
+				Amount   string `json:"amount"`
+				Currency string `json:"currency"`
+			} `json:"overpayment_absolute_threshold"`
+			OverpaymentRelativeThreshold  string `json:"overpayment_relative_threshold"`
+			UnderpaymentAbsoluteThreshold struct {
+				Amount   string `json:"amount"`
+				Currency string `json:"currency"`
+			} `json:"underpayment_absolute_threshold"`
+			UnderpaymentRelativeThreshold string `json:"underpayment_relative_threshold"`
+		}{
+			OverpaymentAbsoluteThreshold: struct {
+				Amount   string `json:"amount"`
+				Currency string `json:"currency"`
+			}{
+				Amount:   "5.00",
+				Currency: "USD",
+			},
+			OverpaymentRelativeThreshold: "0.005",
+			UnderpaymentAbsoluteThreshold: struct {
+				Amount   string `json:"amount"`
+				Currency string `json:"currency"`
+			}{
+				Amount:   "5.00",
+				Currency: "USD",
+			},
+			UnderpaymentRelativeThreshold: "0.005",
+		},
+		AppliedThreshold: struct {
+			Amount   string `json:"amount"`
+			Currency string `json:"currency"`
+		}{},
+		AppliedThresholdType: "",
+		Payments:             nil,
+		Addresses: struct {
+			Bitcoin     string `json:"bitcoin"`
+			BitcoinCash string `json:"bitcoin_cash"`
+			Ethereum    string `json:"ethereum"`
+			Litecoin    string `json:"litecoin"`
+			Dogecoin    string `json:"dogecoin"`
+			USDC        string `json:"usdc"`
+			Dai         string `json:"dai"`
+		}{
+			Bitcoin:     "37rYMGNsMt9CsvrYHtCjKyYrsYFQAmhHa6",
+			BitcoinCash: "",
+			Ethereum:    "0x02fdf03cfbf240d1b8b4dfefab53487e80118534",
+			Litecoin:    "MH5zC7Sya7vsDDMHvFayWXpj4hk7xAD4oi",
+			Dogecoin:    "DBypiqkR67YjWzzGF8nVstk1PtwMbP5NeS",
+			USDC:        "0x02fdf03cfbf240d1b8b4dfefab53487e80118534",
+			Dai:         "0x02fdf03cfbf240d1b8b4dfefab53487e80118534",
+		},
+	}
+}

--- a/pkg/api/stub/context.go
+++ b/pkg/api/stub/context.go
@@ -1,0 +1,51 @@
+package stub
+
+import (
+	"context"
+
+	"github.com/benalucorp/coinbase-commerce-go/pkg/entity"
+)
+
+type contextKey string
+
+const (
+	CtxKeyStub              = contextKey("Coinbase-Commerce-Stub")
+	CtxKeyStubErrDetailResp = contextKey("Coinbase-Commerce-Stub-ErrDetailResp")
+)
+
+func Enable(ctx context.Context) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return context.WithValue(ctx, CtxKeyStub, true)
+}
+
+func Ok(ctx context.Context) bool {
+	if ctx == nil {
+		return false
+	}
+	res, ok := ctx.Value(CtxKeyStub).(bool)
+	if !ok {
+		return false
+	}
+	return res
+}
+
+func SetErrDetailResp(ctx context.Context, err entity.ErrDetailResp) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	ctx = Enable(ctx)
+	return context.WithValue(ctx, CtxKeyStubErrDetailResp, err)
+}
+
+func GetErrDetailResp(ctx context.Context) entity.ErrDetailResp {
+	if ctx == nil {
+		return entity.ErrDetailResp{}
+	}
+	res, ok := ctx.Value(CtxKeyStubErrDetailResp).(entity.ErrDetailResp)
+	if !ok {
+		return entity.ErrDetailResp{}
+	}
+	return res
+}

--- a/pkg/api/stub/error.go
+++ b/pkg/api/stub/error.go
@@ -1,0 +1,16 @@
+package stub
+
+import (
+	"context"
+
+	"github.com/benalucorp/coinbase-commerce-go/pkg/entity"
+)
+
+func CreateErrResp(ctx context.Context) entity.ErrResp {
+	return entity.ErrResp{
+		Error: GetErrDetailResp(ctx),
+		Warnings: []string{
+			"stub: warning",
+		},
+	}
+}

--- a/pkg/api/stub/pagination.go
+++ b/pkg/api/stub/pagination.go
@@ -1,0 +1,22 @@
+package stub
+
+import (
+	"github.com/benalucorp/coinbase-commerce-go/pkg/entity"
+)
+
+func CreatePagination() entity.PaginationResp {
+	return entity.PaginationResp{
+		Order:         "desc",
+		StartingAfter: nil,
+		EndingBefore:  nil,
+		Total:         1,
+		Yielded:       1,
+		Limit:         1,
+		PreviousURI:   nil,
+		NextURI:       nil,
+		CursorRange: []string{
+			"start_cursor",
+			"end_cursor",
+		},
+	}
+}

--- a/pkg/enum/charge.go
+++ b/pkg/enum/charge.go
@@ -17,6 +17,7 @@ const (
 type ChargeUnresolvedContext string
 
 const (
+	ChargeUnresolvedContextNone      ChargeUnresolvedContext = ""
 	ChargeUnresolvedContextUnderpaid ChargeUnresolvedContext = "UNDERPAID"
 	ChargeUnresolvedContextOverpaid  ChargeUnresolvedContext = "OVERPAID"
 	ChargeUnresolvedContextDelayed   ChargeUnresolvedContext = "DELAYED"


### PR DESCRIPTION
Sometimes it makes sense to make an API call without actually calling the API.
In order to support that this library has a built-in stub that can be triggered. 
You can enable stub by injecting a certain value into the context data. 
You can also enforce that certain API calls will always return errors with a specific type and messages.